### PR TITLE
Setting Up Keycloak with Django Allauth and OpenID Connect Locally

### DIFF
--- a/docs/development/10-setup.md
+++ b/docs/development/10-setup.md
@@ -69,14 +69,16 @@ Modify the .env file to include:
 
 ```
 AUTH_PROVIDERS_CONFIG_PATH="./auth_providers_with_secret.json"
-NEOPS_PLUGINS="neops_auth_keycloak"
+NEOPS_PLUGINS="... neops_auth_allauth"
 ```
+
+- Remove: neops_auth_django and neops_auth_keycloak.
 
 ### 2.3 Configure Authentication Providers
 
 To support multiple Keycloak providers, modify the auth_providers_with_secret.json file:
 
-```
+```json
 {
   "providers": [
     {
@@ -110,29 +112,6 @@ poetry run python manage.py runserver
 
 The frontend uses OIDC (OpenID Connect) for authentication.
 
-### 3.1 Configure Authentication in environment.ts
+### 3.1 Configure Authentication in app settings
 
-Modify environment.ts to use the correct Keycloak settings:
-```
-export const environment: EnvironmentConfig = {
-  production: false,
-  graphQLEndpointUrl: 'http://localhost:8000/graphql',
-  useOidc: true,
-  oidcConfig: [
-    {
-      authority: 'http://localhost:8081/realms/neops',
-      redirectUrl: 'http://localhost:4201/integration/cards',
-      postLogoutRedirectUri: 'http://localhost:4201/login',
-      clientId: 'neops-client',
-      scope: 'openid profile email offline_access',
-      responseType: 'code',
-      silentRenew: true,
-      useRefreshToken: true,
-      secureRoutes: ['http://localhost:8000/graphql'],
-    }
-  ]
-};
-```
-
-The frontend should now be running at http://localhost:4201/, and log in using the credentials of the user accounts you have created.
-
+[//]: # (TODO: @Haigos)

--- a/docs/development/10-setup.md
+++ b/docs/development/10-setup.md
@@ -1,0 +1,9 @@
+# Setup development environment
+
+## Setup local OIDC environment
+
+todo
+
+blabla
+
+test

--- a/docs/modules/OIDC.md
+++ b/docs/modules/OIDC.md
@@ -1,5 +1,20 @@
 # OpenID Connect
 
+OIDC (OpenID Connect) is an authentication protocol built on top of OAuth 2.0. It allows clients (like neops-web-sdk) to verify the identity of users using an authorization server (i.e. Keycloak). 
+
 ## How neops support OIDC
+[//]: # (TODO:Haigos)
+
+- Backend
+  - The Neops backend is integrated with Django Allauth, which supports OIDC authentication.
+  - The Keycloak provider is configured in auth_providers_with_secret.json.
+  - Users authenticate through Keycloak (or another OIDC provider), and the backend validates their access tokens.
+
+- Frontend
 
 ## How to configure OIDC
+[//]: # (TODO:Haigos)
+
+- Configure Keycloak as the OIDC provider in auth_providers_with_secret.json (backend).
+- Set up OIDC authentication in environment.ts (frontend).
+- Ensure Keycloak clients (neops-auth for backend, neops-client for frontend) are correctly configured.

--- a/docs/modules/OIDC.md
+++ b/docs/modules/OIDC.md
@@ -1,0 +1,5 @@
+# OpenID Connect
+
+## How neops support OIDC
+
+## How to configure OIDC

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ markdown_extensions:
 nav:
 - Legacy Documentation: legacy
 - Neops 2.0: index.md
+- Modules: modules
 - Components and Services:
   - Task Engine: '!include ./submodules/neops-task-engine/mkdocs_custom.yml'
   - Task Runner: '!include ./submodules/neops-task-runner-py/mkdocs_custom.yml'
@@ -47,6 +48,7 @@ nav:
   - GraphQL Infrastructure: '!include ./submodules/neops-graphql/mkdocs_custom.yml'
   - WebSDK: '!include ./submodules/neops-web-sdk/mkdocs_custom.yml'
   - WebClient: '!include ./submodules/neops-web-client/mkdocs_custom.yml'
+- Development: development
 plugins:
 - search
 - include_dir_to_nav

--- a/mkdocs_custom.yml
+++ b/mkdocs_custom.yml
@@ -3,6 +3,7 @@ site_name: Neops Docs
 nav:
   - Legacy Documentation: legacy
   - Neops 2.0: index.md
+  - Modules: modules
   - Components and Services:
       - Task Engine: '!include ./submodules/neops-task-engine/mkdocs_custom.yml'
       - Task Runner: '!include ./submodules/neops-task-runner-py/mkdocs_custom.yml'
@@ -10,6 +11,7 @@ nav:
       - GraphQL Infrastructure: '!include ./submodules/neops-graphql/mkdocs_custom.yml'
       - WebSDK: '!include ./submodules/neops-web-sdk/mkdocs_custom.yml'
       - WebClient: '!include ./submodules/neops-web-client/mkdocs_custom.yml'
+  - Development: development
 
 
 # --8<-- [start:theme]


### PR DESCRIPTION
# Description

Provides a step-by-step setup of Keycloak authentication with Django Allauth and a frontend using OIDC.

## Checklist:
- [x] PR label has been set
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
