### PR TITLE
docs(theme): enable Material premium formatters across the umbrella

### DIFF
--- a/.make_scripts/mkdocs-documentation/mkdocs_base.yml
+++ b/.make_scripts/mkdocs-documentation/mkdocs_base.yml
@@ -11,6 +11,10 @@ theme:
     - navigation.indexes
     - navigation.sections
     - navigation.tabs
+    # Top tabs stay visible while scrolling.
+    - navigation.tabs.sticky
+    # Breadcrumb path under the top tabs on every page.
+    - navigation.path
     - navigation.top
     - navigation.tracking
     - navigation.instant
@@ -18,6 +22,8 @@ theme:
     - search.suggest
     - search.highlight
     - content.action.edit
+    # Right-side TOC scroll-syncs with the reading position.
+    - toc.follow
   logo: assets/logo.svg
   favicon: assets/favicon.png
 
@@ -62,6 +68,20 @@ markdown_extensions:
       alternate_style: true
   - attr_list
   - md_in_html
+  # Interaction features
+  - pymdownx.keys           # ++ctrl+c++ → kbd
+  - pymdownx.tasklist:      # visible checklist boxes
+      custom_checkbox: true
+  - abbr                    # *[ACL]: ... tooltips on hover
+  - footnotes
+  - pymdownx.tilde          # ~~strike~~
+  - pymdownx.caret          # ^^superscript^^
+  - pymdownx.mark           # ==highlight==
+  # Typographic refinement
+  - smarty                  # 'curly' / "quotes", em-dashes (---), en-dashes (--), …
+  - pymdownx.smartsymbols   # --> → / <== ⇐ / (c) (r) (tm)
+  - pymdownx.magiclink      # bare URLs render as live links
+  - pymdownx.betterem       # cleaner bold/italic edge-case parsing
 # --8<-- [end:markdown_extensions]
 
 # --8<-- [start:plugins]

--- a/.make_scripts/mkdocs-documentation/mkdocs_base.yml
+++ b/.make_scripts/mkdocs-documentation/mkdocs_base.yml
@@ -69,14 +69,9 @@ markdown_extensions:
   - attr_list
   - md_in_html
   # Interaction features
-  - pymdownx.keys           # ++ctrl+c++ → kbd
   - pymdownx.tasklist:      # visible checklist boxes
       custom_checkbox: true
   - abbr                    # *[ACL]: ... tooltips on hover
-  - footnotes
-  - pymdownx.tilde          # ~~strike~~
-  - pymdownx.caret          # ^^superscript^^
-  - pymdownx.mark           # ==highlight==
   # Typographic refinement
   - smarty                  # 'curly' / "quotes", em-dashes (---), en-dashes (--), …
   - pymdownx.smartsymbols   # --> → / <== ⇐ / (c) (r) (tm)

--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -1,0 +1,55 @@
+/* ─────────────────────────────────────────────────────────────────
+ * Tabbed content (pymdownx.tabbed with alternate_style: true)
+ *
+ * Adds a subtle container, a distinct label-row background, and a
+ * shaded content area so each tab group reads as a single visual unit.
+ * Without this, content tabs visually bleed into surrounding prose.
+ * ───────────────────────────────────────────────────────────────── */
+
+.md-typeset .tabbed-set {
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: .4rem;
+  margin: 1.4em 0;
+  overflow: hidden;
+  background: var(--md-default-bg-color);
+}
+
+.md-typeset .tabbed-set > .tabbed-labels {
+  display: flex;
+  background: var(--md-code-bg-color);
+  border-bottom: 1px solid var(--md-default-fg-color--lightest);
+}
+
+.md-typeset .tabbed-set > .tabbed-labels > label {
+  flex: 1;
+  text-align: center;
+  font-weight: 600;
+  opacity: .55;
+  padding: .65rem 1.1rem;
+  font-size: .82rem;
+  transition: opacity .15s ease;
+}
+
+.md-typeset .tabbed-set > .tabbed-labels > label:hover {
+  opacity: .8;
+}
+
+/* Active tab — selected label gets full opacity and an indicator line. */
+.md-typeset .tabbed-set > input:checked + label {
+  opacity: 1;
+  color: var(--md-accent-fg-color);
+}
+
+/* Tab content area — slightly inset so tab boundary is unambiguous. */
+.md-typeset .tabbed-set > .tabbed-content {
+  padding: .9rem 1.2rem;
+}
+
+/* Dark mode polish — the lightest fg color is too pale on dark; nudge. */
+[data-md-color-scheme="slate"] .md-typeset .tabbed-set {
+  border-color: var(--md-default-fg-color--lighter);
+}
+
+[data-md-color-scheme="slate"] .md-typeset .tabbed-set > .tabbed-labels {
+  border-bottom-color: var(--md-default-fg-color--lighter);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,18 @@ markdown_extensions:
     alternate_style: true
 - attr_list
 - md_in_html
+- pymdownx.keys
+- pymdownx.tasklist:
+    custom_checkbox: true
+- abbr
+- footnotes
+- pymdownx.tilde
+- pymdownx.caret
+- pymdownx.mark
+- smarty
+- pymdownx.smartsymbols
+- pymdownx.magiclink
+- pymdownx.betterem
 nav:
 - Home: index.md
 - Getting Started: getting-started
@@ -73,6 +85,8 @@ theme:
   - navigation.indexes
   - navigation.sections
   - navigation.tabs
+  - navigation.tabs.sticky
+  - navigation.path
   - navigation.top
   - navigation.tracking
   - navigation.instant
@@ -80,6 +94,7 @@ theme:
   - search.suggest
   - search.highlight
   - content.action.edit
+  - toc.follow
   logo: assets/logo.svg
   name: material
   palette:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,14 +42,9 @@ markdown_extensions:
     alternate_style: true
 - attr_list
 - md_in_html
-- pymdownx.keys
 - pymdownx.tasklist:
     custom_checkbox: true
 - abbr
-- footnotes
-- pymdownx.tilde
-- pymdownx.caret
-- pymdownx.mark
 - smarty
 - pymdownx.smartsymbols
 - pymdownx.magiclink

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,8 @@ extra:
   - icon: fontawesome/solid/house
     link: https://neops.io
     name: Neops
+extra_css:
+- assets/extra.css
 hooks:
 - .make_scripts/mkdocs-documentation/hooks/inline_nav_include.py
 - .make_scripts/mkdocs-documentation/hooks/fix_symlinks.py

--- a/mkdocs_custom.yml
+++ b/mkdocs_custom.yml
@@ -56,6 +56,10 @@ extra:
 copyright: Copyright &copy; Zebbra AG
 # --8<-- [end:copyright]
 
+# Custom CSS — tab styling (pymdownx.tabbed visual container).
+extra_css:
+  - assets/extra.css
+
 # Overwrite plugins, removes last modified date (git-revision-date-localized)
 plugins:
   - git-authors


### PR DESCRIPTION
## Summary

Adds the markdown extensions, theme features, **and tab-set CSS** the sub-projects need to render polished documentation in the stitched docs.neops.io site. **All changes are non-breaking** — they add functionality only; nothing existing renders differently.

### New markdown extensions

| Extension | Where it's used | What it provides |
|---|---|---|
| `smarty` | site-wide, automatic | Curly quotes (`'` → `'`, `"` → `"`), em-dashes (`---` → `—`), en-dashes (`--` → `–`), ellipses (`...` → `…`) |
| `pymdownx.smartsymbols` | 5+ pages in remote-lab | Auto-arrows (`-->` → `→`, `<==` → `⇐`), `(c) (r) (tm)` marks |
| `pymdownx.magiclink` | scattered | Bare URLs in prose render as live links |
| `pymdownx.betterem` | passive, site-wide | Cleaner bold/italic parsing on edge cases (`*emphasis*,`) |
| `abbr` | every page in remote-lab | `*[ACL]: Access-Control List`-style tooltips on hover (auto-injected via `docs/includes/abbreviations.md`) |
| `pymdownx.tasklist` (`custom_checkbox: true`) | "Your first PR" page | Visible checklist boxes (`- [ ]` / `- [x]`) |

All six are in active use today in at least the [neops-remote-lab](https://github.com/zebbra/neops-remote-lab) sub-site.

### New theme features

- `navigation.tabs.sticky` — top tabs stay visible while scrolling
- `navigation.path` — breadcrumb path under the top tabs
- `toc.follow` — right TOC scroll-syncs with reading position

### Tab-set styling (`docs/assets/extra.css`)

Content tabs (`pymdownx.tabbed`) on a stitched site rendered as bare radio-button labels floating above content, with no visual frame — readers couldn't tell where a tab group started or ended. The new CSS adds:

- Subtle border + rounded corners around the whole tab set
- Distinct background on the label row
- Equal-width tab labels with a hover-opacity transition
- Active tab in the theme's accent color
- Inset content padding so the tab boundary is visible
- Dark-mode polish for the slate palette

Driven by neops-remote-lab's vendor-setup page (the most aggressive content-tabs consumer). Once this PR lands, every sub-project's content-tabs render with a clear, elegant visual container.

## Why

Driven by the [`neops-remote-lab` docs overhaul (zebbra/neops-remote-lab#11)](https://github.com/zebbra/remote-lab/pull/11), which is the first sub-project to fully exploit these features. Once this PR lands, every sub-project can adopt the same patterns without further config work — the next pass on the worker-SDK and workflow-engine docs will benefit immediately.

## Test plan

- [x] Local `mkdocs build` runs cleanly with the new extensions; the only build failure is a pre-existing missing snippet in the `workflow-engine` submodule (`examples/hello-world.workflow.yaml`), unrelated to this PR.
- [x] Diff is purely additive — see the three files touched (mkdocs_base.yml, mkdocs_custom.yml, new extra.css).
- [ ] CI render at docs.neops.io after merge: confirm tooltips appear (abbr), curly quotes render (smarty), em-dashes converted, bare URLs auto-linked, sticky tabs and breadcrumbs visible, content-tab groups have a clear visual container.