### PR TITLE
docs: pull mkdocs-documentation v0.3.0

### DIFF
--- a/.make_scripts/mkdocs-documentation/docs_template/assets/extra.css
+++ b/.make_scripts/mkdocs-documentation/docs_template/assets/extra.css
@@ -1,0 +1,55 @@
+/* ─────────────────────────────────────────────────────────────────
+ * Tabbed content (pymdownx.tabbed with alternate_style: true)
+ *
+ * Adds a subtle container, a distinct label-row background, and a
+ * shaded content area so each tab group reads as a single visual unit.
+ * Without this, content tabs visually bleed into surrounding prose.
+ * ───────────────────────────────────────────────────────────────── */
+
+.md-typeset .tabbed-set {
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: .4rem;
+  margin: 1.4em 0;
+  overflow: hidden;
+  background: var(--md-default-bg-color);
+}
+
+.md-typeset .tabbed-set > .tabbed-labels {
+  display: flex;
+  background: var(--md-code-bg-color);
+  border-bottom: 1px solid var(--md-default-fg-color--lightest);
+}
+
+.md-typeset .tabbed-set > .tabbed-labels > label {
+  flex: 1;
+  text-align: center;
+  font-weight: 600;
+  opacity: .55;
+  padding: .65rem 1.1rem;
+  font-size: .82rem;
+  transition: opacity .15s ease;
+}
+
+.md-typeset .tabbed-set > .tabbed-labels > label:hover {
+  opacity: .8;
+}
+
+/* Active tab — selected label gets full opacity and an indicator line. */
+.md-typeset .tabbed-set > input:checked + label {
+  opacity: 1;
+  color: var(--md-accent-fg-color);
+}
+
+/* Tab content area — slightly inset so tab boundary is unambiguous. */
+.md-typeset .tabbed-set > .tabbed-content {
+  padding: .9rem 1.2rem;
+}
+
+/* Dark mode polish — the lightest fg color is too pale on dark; nudge. */
+[data-md-color-scheme="slate"] .md-typeset .tabbed-set {
+  border-color: var(--md-default-fg-color--lighter);
+}
+
+[data-md-color-scheme="slate"] .md-typeset .tabbed-set > .tabbed-labels {
+  border-bottom-color: var(--md-default-fg-color--lighter);
+}

--- a/.make_scripts/mkdocs-documentation/mkdocs_base.yml
+++ b/.make_scripts/mkdocs-documentation/mkdocs_base.yml
@@ -11,6 +11,10 @@ theme:
     - navigation.indexes
     - navigation.sections
     - navigation.tabs
+    # Top tabs stay visible while scrolling.
+    - navigation.tabs.sticky
+    # Breadcrumb path under the top tabs on every page.
+    - navigation.path
     - navigation.top
     - navigation.tracking
     - navigation.instant
@@ -18,8 +22,17 @@ theme:
     - search.suggest
     - search.highlight
     - content.action.edit
+    # Right-side TOC scroll-syncs with the reading position.
+    - toc.follow
   logo: assets/logo.svg
   favicon: assets/favicon.png
+
+# Shared styling — extra.css is a "managed asset" copied into each project's
+# docs/assets/ on every `make doc-update-assets` cycle (see
+# setup_documentation.py::sync_managed_docs_assets). Project-specific styling
+# should live in a separate file referenced alongside this one.
+extra_css:
+  - assets/extra.css
 
 hooks:
   - .make_scripts/mkdocs-documentation/hooks/inline_nav_include.py
@@ -62,6 +75,15 @@ markdown_extensions:
       alternate_style: true
   - attr_list
   - md_in_html
+  # Interaction features
+  - pymdownx.tasklist:      # visible checklist boxes
+      custom_checkbox: true
+  - abbr                    # *[ACL]: ... tooltips on hover
+  # Typographic refinement
+  - smarty                  # 'curly' / "quotes", em-dashes (---), en-dashes (--), …
+  - pymdownx.smartsymbols   # --> → / <== ⇐ / (c) (r) (tm)
+  - pymdownx.magiclink      # bare URLs render as live links
+  - pymdownx.betterem       # cleaner bold/italic edge-case parsing
 # --8<-- [end:markdown_extensions]
 
 # --8<-- [start:plugins]

--- a/.make_scripts/mkdocs-documentation/setup_documentation.py
+++ b/.make_scripts/mkdocs-documentation/setup_documentation.py
@@ -51,11 +51,7 @@ def is_file_dirty(filename):
 
     # 2. Check if we are inside a Git repository
     # rev-parse returns 0 if inside a repo, non-zero otherwise
-    is_git = subprocess.run(
-        ["git", "rev-parse", "--is-inside-work-tree"],
-        capture_output=True,
-        text=True
-    )
+    is_git = subprocess.run(["git", "rev-parse", "--is-inside-work-tree"], capture_output=True, text=True)
     if is_git.returncode != 0:
         return False
 
@@ -66,6 +62,7 @@ def is_file_dirty(filename):
 
     # Check the returncode. Non-zero indicates a difference (dirty file)
     return result.returncode != 0
+
 
 def read_file(file_name):
     with open(file_name) as f:
@@ -88,11 +85,8 @@ def merge_mkdocs_yml():
     if not is_file_dirty(MKDOCS_RES):
         write_file(
             MKDOCS_RES,
-            RES_HEADER
-            + yaml.dump(yaml_res)
-            .replace("tag:yaml.org,2002:", "!!")
-            .replace("'!relative'", "!relative"),
-            )
+            RES_HEADER + yaml.dump(yaml_res).replace("tag:yaml.org,2002:", "!!").replace("'!relative'", "!relative"),
+        )
     else:
         raise Exception(f"{MKDOCS_RES} is dirty, stage or commit first")
 
@@ -112,11 +106,40 @@ def ensure_docs_dir():
         shutil.copytree(MKDOCS_DOCS_TEMPLATE, "docs")
 
 
+# Files under docs_template/ that are *managed* by this pipeline — they get
+# pushed into every project's docs/ tree on every setup run, overwriting any
+# local copy. Use this for shared styling / assets that should stay in sync
+# across all neops projects (e.g. content-tab CSS).
+#
+# Project-specific overrides should live under a different filename so they
+# aren't clobbered (e.g. docs/assets/project-extra.css, with both files
+# referenced from extra_css in the project's mkdocs_custom.yml).
+MANAGED_DOCS_ASSETS = [
+    "assets/extra.css",
+]
+
+
+def sync_managed_docs_assets():
+    """
+    Copy each MANAGED_DOCS_ASSETS file from docs_template/ into the project's
+    docs/ tree, creating any missing parent directories. Runs unconditionally
+    so existing projects pick up upstream styling fixes via `make doc-update-assets`.
+    """
+    for rel_path in MANAGED_DOCS_ASSETS:
+        src = os.path.join(MKDOCS_DOCS_TEMPLATE, rel_path)
+        dst = os.path.join("docs", rel_path)
+        if not os.path.exists(src):
+            # Defensive: skip silently if the upstream template doesn't ship
+            # this asset (e.g. older release before the file was added).
+            continue
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        shutil.copy(src, dst)
+        print(f"++ Synced managed asset: {dst}")
+
+
 def is_ignored_by_git(path):
     # Use git check-ignore command to see if the path is ignored
-    result = subprocess.run(
-        ["git", "check-ignore", path], capture_output=True, text=True
-    )
+    result = subprocess.run(["git", "check-ignore", path], capture_output=True, text=True)
 
     # If the result's stdout is not empty, the path is ignored
     return result.stdout != ""
@@ -191,6 +214,7 @@ def main():
     ensure_mkdocs_custom()
     merge_mkdocs_yml()
     ensure_docs_dir()
+    sync_managed_docs_assets()
     create_symlinks()
 
 

--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -1,0 +1,55 @@
+/* ─────────────────────────────────────────────────────────────────
+ * Tabbed content (pymdownx.tabbed with alternate_style: true)
+ *
+ * Adds a subtle container, a distinct label-row background, and a
+ * shaded content area so each tab group reads as a single visual unit.
+ * Without this, content tabs visually bleed into surrounding prose.
+ * ───────────────────────────────────────────────────────────────── */
+
+.md-typeset .tabbed-set {
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: .4rem;
+  margin: 1.4em 0;
+  overflow: hidden;
+  background: var(--md-default-bg-color);
+}
+
+.md-typeset .tabbed-set > .tabbed-labels {
+  display: flex;
+  background: var(--md-code-bg-color);
+  border-bottom: 1px solid var(--md-default-fg-color--lightest);
+}
+
+.md-typeset .tabbed-set > .tabbed-labels > label {
+  flex: 1;
+  text-align: center;
+  font-weight: 600;
+  opacity: .55;
+  padding: .65rem 1.1rem;
+  font-size: .82rem;
+  transition: opacity .15s ease;
+}
+
+.md-typeset .tabbed-set > .tabbed-labels > label:hover {
+  opacity: .8;
+}
+
+/* Active tab — selected label gets full opacity and an indicator line. */
+.md-typeset .tabbed-set > input:checked + label {
+  opacity: 1;
+  color: var(--md-accent-fg-color);
+}
+
+/* Tab content area — slightly inset so tab boundary is unambiguous. */
+.md-typeset .tabbed-set > .tabbed-content {
+  padding: .9rem 1.2rem;
+}
+
+/* Dark mode polish — the lightest fg color is too pale on dark; nudge. */
+[data-md-color-scheme="slate"] .md-typeset .tabbed-set {
+  border-color: var(--md-default-fg-color--lighter);
+}
+
+[data-md-color-scheme="slate"] .md-typeset .tabbed-set > .tabbed-labels {
+  border-bottom-color: var(--md-default-fg-color--lighter);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,8 @@ extra:
   - icon: fontawesome/solid/house
     link: https://neops.io
     name: Neops
+extra_css:
+- assets/extra.css
 hooks:
 - .make_scripts/mkdocs-documentation/hooks/inline_nav_include.py
 - .make_scripts/mkdocs-documentation/hooks/fix_symlinks.py
@@ -42,6 +44,13 @@ markdown_extensions:
     alternate_style: true
 - attr_list
 - md_in_html
+- pymdownx.tasklist:
+    custom_checkbox: true
+- abbr
+- smarty
+- pymdownx.smartsymbols
+- pymdownx.magiclink
+- pymdownx.betterem
 nav:
 - Home: index.md
 - Getting Started: getting-started
@@ -73,6 +82,8 @@ theme:
   - navigation.indexes
   - navigation.sections
   - navigation.tabs
+  - navigation.tabs.sticky
+  - navigation.path
   - navigation.top
   - navigation.tracking
   - navigation.instant
@@ -80,6 +91,7 @@ theme:
   - search.suggest
   - search.highlight
   - content.action.edit
+  - toc.follow
   logo: assets/logo.svg
   name: material
   palette:


### PR DESCRIPTION
## Summary

Refreshes the vendored \`.make_scripts/mkdocs-documentation/\` from the v0.3.0 release of zebbra/mkdocs-documentation (PRs #6 + #7), picking up:

- **Theme features**: \`navigation.tabs.sticky\`, \`navigation.path\`, \`toc.follow\`.
- **Markdown extensions**: \`pymdownx.tasklist\` (\`custom_checkbox: true\`), \`abbr\`, \`smarty\`, \`pymdownx.smartsymbols\`, \`pymdownx.magiclink\`, \`pymdownx.betterem\`.
- **Wires** \`extra_css: [assets/extra.css]\` in \`mkdocs_base.yml\`.
- **\`setup_documentation.py\`** gains \`sync_managed_docs_assets()\` — pushes managed assets (currently \`extra.css\`) into each project's \`docs/assets/\` on every \`doc-update-assets\` cycle.

\`docs/assets/extra.css\` (new) — managed file, content matches the canonical version. Synced automatically by \`setup_documentation.py\`; any local edits will be overwritten on the next sync. Project-specific styling should live in a separate file (e.g. \`project-extra.css\`).

\`mkdocs_custom.yml\` unchanged — main never carried the extension/theme-feature overrides that the typography work introduced on the (now-closed) feature branch, so nothing to clean up here.

## Verification

- \`make doc-update-assets\` ran cleanly against v0.3.0.
- \`mkdocs build\` succeeds.
- \`mkdocs build --strict\` aborts on **887 pre-existing warnings** about \`neops-workflow-engine/schema/doc/rootworkflow.md\` anchor links — none related to this PR. Sample:
  > Doc file 'neops-workflow-engine/schema/doc/rootworkflow.md' contains a link '#type-10', but there is no such anchor on this page.

## Replaces / supersedes

\`docs/material-typography-2026-04-27\` (the original umbrella PR #20) — closed earlier as wrong layer; the canonical content now lives in \`zebbra/mkdocs-documentation\` and is consumed via this update.

## Test plan

- [x] \`make doc-update-assets\` clean.
- [x] \`mkdocs build\` clean (887 pre-existing strict warnings unrelated).
- [ ] Visual spot-check on the rendered site: confirm sticky tabs, breadcrumbs, abbreviation tooltips, content-tab styling.