### PR TITLE
docs: sync mkdocs-documentation v0.4.0 (tab-aware TOC + URL guard)

### DIFF
--- a/.make_scripts/mkdocs-documentation/docs_template/assets/extra.css
+++ b/.make_scripts/mkdocs-documentation/docs_template/assets/extra.css
@@ -1,55 +1,137 @@
 /* ─────────────────────────────────────────────────────────────────
  * Tabbed content (pymdownx.tabbed with alternate_style: true)
  *
- * Adds a subtle container, a distinct label-row background, and a
- * shaded content area so each tab group reads as a single visual unit.
- * Without this, content tabs visually bleed into surrounding prose.
+ * Goal: minimal but distinguishable. Subtle outer box, slim labels,
+ * dark+heavy active label, accent-coloured moving underline.
+ *
+ * pymdownx alternate_style puts inputs as siblings of .tabbed-labels
+ * (not adjacent to each label), so the active label has to be
+ * targeted via the nth-child positional pattern Material uses
+ * internally — `input:nth-child(N):checked ~ .tabbed-labels > :nth-child(N)`.
+ * That's why this file lists positions 1..8 explicitly.
  * ───────────────────────────────────────────────────────────────── */
 
+/* Container — subtle outer box so the pane reads as a unit. The
+ * labels row scrolls naturally with content; we deliberately do NOT
+ * make it sticky (sticky-positioning under Material's auto-hiding
+ * header is a source of subtle racing bugs).
+ *
+ * scroll-margin-top mirrors the value Material uses on :target
+ * elements (3.6rem mobile, 6rem on desktop where the header is
+ * lifted with the tab bar). When scrollIntoView lands on the
+ * tabbed-set, the labels row clears Material's sticky header
+ * instead of disappearing behind it. */
 .md-typeset .tabbed-set {
-  border: 1px solid var(--md-default-fg-color--lightest);
-  border-radius: .4rem;
-  margin: 1.4em 0;
-  overflow: hidden;
+  margin: 1.2em 0;
   background: var(--md-default-bg-color);
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: .35rem;
+  overflow: hidden;
+  scroll-margin-top: 3.6rem;
 }
 
+@media screen and (min-width: 76.25em) {
+  .md-header--lifted ~ .md-container .md-typeset .tabbed-set {
+    scroll-margin-top: 6rem;
+  }
+}
+
+/* Label row — slim, no fill, single divider line at the bottom. */
 .md-typeset .tabbed-set > .tabbed-labels {
   display: flex;
-  background: var(--md-code-bg-color);
+  gap: 0;
+  margin: 0;
+  padding: 0 .25rem;
+  background: var(--md-default-bg-color);
+  box-shadow: none;
   border-bottom: 1px solid var(--md-default-fg-color--lightest);
 }
 
+/* Tighten Material's chunky default label padding + font size. */
 .md-typeset .tabbed-set > .tabbed-labels > label {
-  flex: 1;
-  text-align: center;
+  padding: .35rem .85rem;
+  font-size: .72rem;
   font-weight: 600;
-  opacity: .55;
-  padding: .65rem 1.1rem;
-  font-size: .82rem;
-  transition: opacity .15s ease;
+  white-space: nowrap;
 }
 
-.md-typeset .tabbed-set > .tabbed-labels > label:hover {
-  opacity: .8;
+/* Active label — heavier weight (Material already handles colour
+ * via its own nth-child rules, painting active in default-fg-color
+ * and inactive in default-fg-color--light). */
+.md-typeset .tabbed-set > input:first-child:checked ~ .tabbed-labels > :first-child,
+.md-typeset .tabbed-set > input:nth-child(2):checked ~ .tabbed-labels > :nth-child(2),
+.md-typeset .tabbed-set > input:nth-child(3):checked ~ .tabbed-labels > :nth-child(3),
+.md-typeset .tabbed-set > input:nth-child(4):checked ~ .tabbed-labels > :nth-child(4),
+.md-typeset .tabbed-set > input:nth-child(5):checked ~ .tabbed-labels > :nth-child(5),
+.md-typeset .tabbed-set > input:nth-child(6):checked ~ .tabbed-labels > :nth-child(6),
+.md-typeset .tabbed-set > input:nth-child(7):checked ~ .tabbed-labels > :nth-child(7),
+.md-typeset .tabbed-set > input:nth-child(8):checked ~ .tabbed-labels > :nth-child(8) {
+  font-weight: 800;
 }
 
-/* Active tab — selected label gets full opacity and an indicator line. */
-.md-typeset .tabbed-set > input:checked + label {
-  opacity: 1;
-  color: var(--md-accent-fg-color);
+/* Active indicator — keep Material's JS-driven moving underline,
+ * but recolour from default-fg to the accent for a pop of colour. */
+.js .md-typeset .tabbed-set > .tabbed-labels:before {
+  background: var(--md-accent-fg-color);
 }
 
-/* Tab content area — slightly inset so tab boundary is unambiguous. */
+/* Content area — small inset so code blocks and prose breathe inside
+ * the bordered container. */
 .md-typeset .tabbed-set > .tabbed-content {
-  padding: .9rem 1.2rem;
+  padding: .8rem 1rem;
 }
 
-/* Dark mode polish — the lightest fg color is too pale on dark; nudge. */
+/* Trim the default top margin of code blocks inside the tab so they
+ * don't double-pad against the content's top inset. */
+.md-typeset .tabbed-set > .tabbed-content .tabbed-block > pre:first-child,
+.md-typeset .tabbed-set > .tabbed-content .tabbed-block > div:first-child {
+  margin-top: 0;
+}
+
+/* Dark mode — divider + border use a slightly heavier token. */
 [data-md-color-scheme="slate"] .md-typeset .tabbed-set {
   border-color: var(--md-default-fg-color--lighter);
 }
 
 [data-md-color-scheme="slate"] .md-typeset .tabbed-set > .tabbed-labels {
   border-bottom-color: var(--md-default-fg-color--lighter);
+}
+
+/* ─────────────────────────────────────────────────────────────────
+ * Tab-aware TOC entries (rendered by extra.js).
+ *
+ * Synthetic parent entries created from a tab label use `--tab` modifier
+ * classes. Style them slightly differently from real heading entries so
+ * the reader can tell at a glance that "Nokia SR Linux" is a tab, not
+ * an H3. Italic + a small chevron prefix does the trick.
+ * ───────────────────────────────────────────────────────────────── */
+
+.md-nav__link--tab {
+  font-style: italic;
+  opacity: .8;
+}
+
+.md-nav__link--tab::before {
+  content: "▸ ";
+  margin-right: .15rem;
+  opacity: .55;
+}
+
+.md-nav__link--tab:hover {
+  opacity: 1;
+}
+
+/* Hide the children of any synthetic tab-group whose tab isn't
+ * currently active. Keeps Material's scroll-spy from highlighting
+ * headings in hidden tabs (which all collapse to the same scroll
+ * position when their parent .tabbed-block is display:none). */
+.md-nav__item--tab-inactive > .md-nav {
+  display: none;
+}
+
+/* Active-tab marker — a small chevron rotation so the user can tell
+ * at a glance which tab's children are showing. */
+.md-nav__item--tab-active > .md-nav__link--tab::before {
+  content: "▾ ";
+  opacity: .8;
 }

--- a/.make_scripts/mkdocs-documentation/docs_template/assets/extra.js
+++ b/.make_scripts/mkdocs-documentation/docs_template/assets/extra.js
@@ -1,0 +1,492 @@
+/* Tab-aware TOC for pymdownx.tabbed (alternate_style: true).
+ *
+ * What this script does (and ONLY this — scope is intentionally small):
+ *
+ *   1. When a TOC entry points to a heading inside an inactive tab,
+ *      clicking it activates the tab so the heading is visible. We
+ *      restore the target's `id` synchronously in the capture phase
+ *      so Material's bubble-phase scroll-into-view (and the browser's
+ *      native anchor jump) find the live element with no race.
+ *
+ *   2. The flat TOC is restructured into synthetic per-tab parent
+ *      entries: any consecutive run of TOC items whose targets live
+ *      in the same tab gets grouped under a parent labelled with
+ *      that tab's name. Clicking the parent activates the tab.
+ *
+ *   3. Synthetic group expansion (▾ active, ▸ inactive) tracks the
+ *      currently active tab.
+ *
+ *   4. Material's scroll-spy is prevented from polluting the URL
+ *      with fragments that point to inactive-tab headings via:
+ *
+ *        a. Stripping the `id` attribute of every element inside an
+ *           inactive .tabbed-block (parked on `data-tab-id`); some
+ *           Material codepaths walk live `[id]` and skip them.
+ *
+ *        b. A narrow filter on history.replaceState/pushState that
+ *           drops calls whose fragment targets an element inside an
+ *           inactive tab. Material caches `[id]` references at init
+ *           time, so this is the necessary belt-and-braces.
+ *
+ * What this script intentionally does NOT do:
+ *
+ *   - No sticky positioning of the tab labels row. (CSS handles tab
+ *     styling but the labels row scrolls naturally with content.)
+ *   - No header-height tracking. Material's autohiding header is
+ *     left alone.
+ *   - No custom scrollIntoView. Material's instant-nav and the
+ *     browser's native anchor jump handle scrolling. Activating the
+ *     correct tab in the capture phase is enough — the live `id`
+ *     restored there is what Material/browser scrolls to.
+ *
+ * Hooked into:
+ *   - DOMContentLoaded                  (initial setup)
+ *   - hashchange                        (URL fragment changes)
+ *   - Material's document$ stream       (instant navigation)
+ *   - radio change events               (tab switching)
+ *   - capture-phase clicks              (TOC link interception)
+ */
+(function () {
+  /* ──────────────────────────────────────────────────────────────
+   *  Selectors
+   * ────────────────────────────────────────────────────────────── */
+
+  const SEL_TABBED_SET = ".tabbed-set";
+  const SEL_TABBED_BLOCK = ".tabbed-block";
+  const SEL_TABBED_LABELS = ".tabbed-labels";
+  const SEL_SIDEBAR_SECONDARY = ".md-sidebar--secondary";
+  const SEL_TOC_NAV = SEL_SIDEBAR_SECONDARY + " nav";
+
+  const cssEscape =
+    window.CSS && typeof CSS.escape === "function"
+      ? CSS.escape.bind(CSS)
+      : (s) => String(s).replace(/[^a-zA-Z0-9_-]/g, (c) => "\\" + c);
+
+  /* ──────────────────────────────────────────────────────────────
+   *  ID management for tabbed-blocks
+   *
+   *  When a tab is inactive, we move every descendant `id` onto
+   *  `data-tab-id`. When the tab becomes active, we restore them.
+   *  Idempotent on both sides.
+   * ────────────────────────────────────────────────────────────── */
+
+  function stripIdsInBlock(block) {
+    for (const el of block.querySelectorAll("[id]")) {
+      el.setAttribute("data-tab-id", el.id);
+      el.removeAttribute("id");
+    }
+  }
+
+  function restoreIdsInBlock(block) {
+    for (const el of block.querySelectorAll("[data-tab-id]")) {
+      const original = el.getAttribute("data-tab-id");
+      if (original && !el.id) el.setAttribute("id", original);
+      el.removeAttribute("data-tab-id");
+    }
+  }
+
+  function syncIdsToActiveTab(tabbedSet) {
+    const inputs = tabbedSet.querySelectorAll(
+      ':scope > input[type="radio"]'
+    );
+    const blocks = tabbedSet.querySelectorAll(
+      ":scope > .tabbed-content > " + SEL_TABBED_BLOCK
+    );
+    for (let i = 0; i < inputs.length; i++) {
+      const block = blocks[i];
+      if (!block) continue;
+      if (inputs[i].checked) restoreIdsInBlock(block);
+      else stripIdsInBlock(block);
+    }
+  }
+
+  function syncAllTabbedSets() {
+    for (const set of document.querySelectorAll(SEL_TABBED_SET)) {
+      syncIdsToActiveTab(set);
+    }
+  }
+
+  /* ──────────────────────────────────────────────────────────────
+   *  Fragment → element lookup (id OR data-tab-id)
+   * ────────────────────────────────────────────────────────────── */
+
+  function findTargetByFragment(fragment) {
+    if (!fragment || fragment === "#") return null;
+    let id;
+    try {
+      id = decodeURIComponent(fragment.slice(1));
+    } catch (e) {
+      return null;
+    }
+    return (
+      document.getElementById(id) ||
+      document.querySelector('[data-tab-id="' + cssEscape(id) + '"]')
+    );
+  }
+
+  /* ──────────────────────────────────────────────────────────────
+   *  Tab activation
+   *
+   *  Clicking the label fires Material's indicator-animator (setting
+   *  input.checked directly does NOT fire change). Synchronous in
+   *  the capture phase: the target's id is live by the time
+   *  Material/browser scroll in bubble phase.
+   * ────────────────────────────────────────────────────────────── */
+
+  function activateTab(tabbedSet, blockIndex) {
+    const inputs = tabbedSet.querySelectorAll(
+      ':scope > input[type="radio"]'
+    );
+    const labels = tabbedSet.querySelectorAll(
+      ":scope > " + SEL_TABBED_LABELS + " > label"
+    );
+    const input = inputs[blockIndex];
+    const label = labels[blockIndex];
+    if (!input || input.checked) return;
+
+    if (label) label.click();
+    else input.checked = true;
+
+    /* The radio change handler we install at the bottom of this
+     * file runs syncIdsToActiveTab + syncTocVisibility. Defensively
+     * call them here too in case the change event does not fire
+     * (e.g., element detached at the time of the click). */
+    syncIdsToActiveTab(tabbedSet);
+    syncTocVisibility();
+  }
+
+  function activateTabForFragment(fragment) {
+    if (!fragment || fragment === "#") return;
+    const target = findTargetByFragment(fragment);
+    if (!target) return;
+    const block = target.closest(SEL_TABBED_BLOCK);
+    if (!block) return;
+    const tabbedSet = block.closest(SEL_TABBED_SET);
+    if (!tabbedSet) return;
+    const blocks = Array.from(
+      tabbedSet.querySelectorAll(
+        ":scope > .tabbed-content > " + SEL_TABBED_BLOCK
+      )
+    );
+    const blockIndex = blocks.indexOf(block);
+    if (blockIndex < 0) return;
+    activateTab(tabbedSet, blockIndex);
+  }
+
+  function activateTabForHash() {
+    activateTabForFragment(window.location.hash);
+  }
+
+  /* ──────────────────────────────────────────────────────────────
+   *  TOC restructure — group entries by their parent tab
+   * ────────────────────────────────────────────────────────────── */
+
+  function tabInfoForFragment(fragment) {
+    if (!fragment) return null;
+    const target = findTargetByFragment(fragment);
+    if (!target) return null;
+    const block = target.closest(SEL_TABBED_BLOCK);
+    if (!block) return null;
+    const tabbedSet = block.closest(SEL_TABBED_SET);
+    if (!tabbedSet) return null;
+    const blocks = Array.from(
+      tabbedSet.querySelectorAll(
+        ":scope > .tabbed-content > " + SEL_TABBED_BLOCK
+      )
+    );
+    const blockIndex = blocks.indexOf(block);
+    if (blockIndex < 0) return null;
+    const labels = tabbedSet.querySelectorAll(
+      ":scope > " + SEL_TABBED_LABELS + " > label"
+    );
+    const labelText = labels[blockIndex]?.textContent.trim();
+    if (!labelText) return null;
+    return {
+      tabbedSet,
+      blockIndex,
+      labelText,
+      key:
+        (tabbedSet.dataset.tabs || tabbedSet.id || "set") + ":" + blockIndex,
+    };
+  }
+
+  function buildSyntheticParent(tabInfo) {
+    const li = document.createElement("li");
+    li.className = "md-nav__item md-nav__item--tab";
+    li.dataset.tabSet = tabInfo.tabbedSet.dataset.tabs || "";
+    li.dataset.tabIndex = String(tabInfo.blockIndex);
+
+    const a = document.createElement("a");
+    a.className = "md-nav__link md-nav__link--tab";
+    a.href = "#";
+    a.textContent = tabInfo.labelText;
+    a.title = 'Open the "' + tabInfo.labelText + '" tab';
+
+    a.addEventListener("click", (e) => {
+      /* The href="#" + preventDefault + stopPropagation combo
+       * deliberately keeps Material entirely out of this click:
+       *
+       *   - href="#" means there's no real fragment for Material's
+       *     instant-nav to treat as a navigation.
+       *   - preventDefault stops the browser's default "#" jump
+       *     (which would put a stray "#" in the URL).
+       *   - stopPropagation stops Material's bubble-phase click
+       *     handler from running.
+       *
+       * With Material bypassed, NO ONE else is going to call
+       * scrollTo on this click. Our requestAnimationFrame scroll
+       * then runs unopposed — no race, no retry loop, robust in
+       * every browser. This is exactly the "easy, race-free path"
+       * for synthetic group clicks because we own the click in
+       * full. (TOC sub-entries with real hash fragments still flow
+       * through Material untouched by our generic handler.) */
+      e.preventDefault();
+      e.stopPropagation();
+      activateTab(tabInfo.tabbedSet, tabInfo.blockIndex);
+      requestAnimationFrame(() => {
+        tabInfo.tabbedSet.scrollIntoView({ block: "start" });
+      });
+    });
+
+    li.appendChild(a);
+
+    const nestedNav = document.createElement("nav");
+    nestedNav.className = "md-nav md-nav--secondary";
+    nestedNav.setAttribute("aria-label", tabInfo.labelText);
+    const nestedUl = document.createElement("ul");
+    nestedUl.className = "md-nav__list";
+    nestedNav.appendChild(nestedUl);
+    li.appendChild(nestedNav);
+
+    return { li, nestedUl };
+  }
+
+  function syncTocVisibility() {
+    const groups = document.querySelectorAll(".md-nav__item--tab");
+    for (const group of groups) {
+      const setId = group.dataset.tabSet;
+      const idx = parseInt(group.dataset.tabIndex, 10);
+      if (Number.isNaN(idx)) continue;
+      const tabbedSet = setId
+        ? document.querySelector(
+            SEL_TABBED_SET + '[data-tabs="' + cssEscape(setId) + '"]'
+          )
+        : null;
+      if (!tabbedSet) continue;
+      const inputs = tabbedSet.querySelectorAll(
+        ':scope > input[type="radio"]'
+      );
+      const isActive = inputs[idx]?.checked === true;
+      group.classList.toggle("md-nav__item--tab-active", isActive);
+      group.classList.toggle("md-nav__item--tab-inactive", !isActive);
+    }
+  }
+
+  function restructureTocList(navList) {
+    const items = Array.from(navList.children).filter(
+      (el) =>
+        el.tagName === "LI" && !el.classList.contains("md-nav__item--tab")
+    );
+    if (items.length === 0) return 0;
+
+    const infos = items.map((item) => {
+      const link = item.querySelector(":scope > a.md-nav__link");
+      /* link.hash returns just the fragment regardless of whether
+       * the href is relative ("#foo") or absolute (Material rewrites
+       * TOC hrefs to absolute form during instant nav). */
+      const fragment = link?.hash;
+      return tabInfoForFragment(fragment);
+    });
+
+    let group = null;
+    const commits = [];
+    for (let i = 0; i < items.length; i++) {
+      const info = infos[i];
+      if (!info) {
+        if (group) commits.push(group);
+        group = null;
+        continue;
+      }
+      if (!group || group.key !== info.key) {
+        if (group) commits.push(group);
+        group = { ...info, items: [items[i]] };
+      } else {
+        group.items.push(items[i]);
+      }
+    }
+    if (group) commits.push(group);
+
+    for (const g of commits) {
+      const first = g.items[0];
+      const parent = first.parentNode;
+      const { li, nestedUl } = buildSyntheticParent(g);
+      parent.insertBefore(li, first);
+      for (const item of g.items) nestedUl.appendChild(item);
+    }
+    return commits.length;
+  }
+
+  function restructureToc() {
+    const tocRoot = document.querySelector(SEL_TOC_NAV);
+    if (!tocRoot) return;
+    if (tocRoot.dataset.tabRestructured === "done") return;
+    const lists = tocRoot.querySelectorAll(".md-nav__list");
+    for (const list of lists) restructureTocList(list);
+    tocRoot.dataset.tabRestructured = "done";
+    syncTocVisibility();
+  }
+
+  /* ──────────────────────────────────────────────────────────────
+   *  URL pollution guard
+   *
+   *  Material's scroll-spy writes URL fragments that can point to
+   *  inactive-tab headings (Material caches an `[id]` map at init
+   *  time so DOM-level id stripping isn't enough on its own). We
+   *  filter history.replaceState/pushState to drop calls whose
+   *  fragment targets an inactive-tab element.
+   *
+   *  Pure DOM check at write time. No timing, no race. Idempotent
+   *  install. Fails-open: if our predicate throws or finds nothing,
+   *  the original call goes through.
+   * ────────────────────────────────────────────────────────────── */
+
+  function fragmentTargetsInactiveTab(url) {
+    if (!url) return false;
+    let parsed;
+    try {
+      parsed = new URL(url, document.baseURI);
+    } catch (e) {
+      return false;
+    }
+    if (!parsed.hash || parsed.hash === "#") return false;
+    const target = findTargetByFragment(parsed.hash);
+    if (!target) return false;
+    const block = target.closest(SEL_TABBED_BLOCK);
+    if (!block) return false;
+    const tabbedSet = block.closest(SEL_TABBED_SET);
+    if (!tabbedSet) return false;
+    const blocks = Array.from(
+      tabbedSet.querySelectorAll(
+        ":scope > .tabbed-content > " + SEL_TABBED_BLOCK
+      )
+    );
+    const blockIndex = blocks.indexOf(block);
+    if (blockIndex < 0) return false;
+    const inputs = tabbedSet.querySelectorAll(
+      ':scope > input[type="radio"]'
+    );
+    return inputs[blockIndex] && !inputs[blockIndex].checked;
+  }
+
+  function installUrlGuard() {
+    if (history.__neopsTabsGuard) return;
+    history.__neopsTabsGuard = true;
+
+    const wrap = (origName) => {
+      const orig = history[origName].bind(history);
+      history[origName] = function (state, title, url) {
+        try {
+          if (fragmentTargetsInactiveTab(url)) return;
+        } catch (e) {
+          /* Never break navigation because of us. */
+        }
+        return orig(state, title, url);
+      };
+    };
+
+    wrap("replaceState");
+    wrap("pushState");
+  }
+
+  /* ──────────────────────────────────────────────────────────────
+   *  Sidebar rebuild observer — Material replaces the secondary
+   *  sidebar on instant navigation. Our `done` flag lives on the
+   *  tocRoot element, so a fresh <nav> from Material has no flag
+   *  and our restructure re-applies.
+   * ────────────────────────────────────────────────────────────── */
+
+  function watchSidebarForRebuilds() {
+    const sidebar = document.querySelector(SEL_SIDEBAR_SECONDARY);
+    if (!sidebar) return;
+    new MutationObserver(restructureToc).observe(sidebar, {
+      childList: true,
+      subtree: true,
+    });
+  }
+
+  /* ──────────────────────────────────────────────────────────────
+   *  Lifecycle wiring
+   * ────────────────────────────────────────────────────────────── */
+
+  function run() {
+    syncAllTabbedSets();
+    restructureToc();
+    activateTabForHash();
+  }
+
+  function init() {
+    /* Install the URL guard FIRST so it covers any subsequent
+     * replaceState/pushState (ours and Material's). Idempotent. */
+    installUrlGuard();
+    run();
+    watchSidebarForRebuilds();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+
+  window.addEventListener("hashchange", activateTabForHash);
+
+  /* Capture-phase click handler: when a TOC link points into an
+   * inactive tab, activate the tab synchronously so the target's
+   * `id` is live when Material's bubble-phase handler (and the
+   * browser's native anchor jump) try to scroll to it. We do NOT
+   * preventDefault, do NOT stopPropagation — the natural click
+   * lifecycle handles URL update and scrolling. */
+  document.addEventListener(
+    "click",
+    (e) => {
+      if (e.defaultPrevented) return;
+      if (e.button !== 0) return;
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+      const a = e.target.closest && e.target.closest("a");
+      if (!a || !a.hash || a.hash === "#") return;
+      if (a.pathname !== window.location.pathname) return;
+      if (a.target && a.target !== "" && a.target !== "_self") return;
+      activateTabForFragment(a.hash);
+    },
+    true
+  );
+
+  /* When the user clicks a tab label (or the tab radio changes for
+   * any other reason), re-sync ID stripping and TOC visibility. */
+  document.addEventListener(
+    "change",
+    (e) => {
+      const target = e.target;
+      if (
+        target instanceof HTMLInputElement &&
+        target.type === "radio" &&
+        target.parentElement?.classList.contains("tabbed-set")
+      ) {
+        const tabbedSet = target.parentElement;
+        syncIdsToActiveTab(tabbedSet);
+        syncTocVisibility();
+      }
+    },
+    true
+  );
+
+  /* Material's document$ Subject fires once on subscribe AND on
+   * every instant navigation. Re-running run() is idempotent —
+   * each step early-returns when its work is already done. */
+  if (
+    typeof document$ !== "undefined" &&
+    typeof document$.subscribe === "function"
+  ) {
+    document$.subscribe(run);
+  }
+})();

--- a/.make_scripts/mkdocs-documentation/mkdocs_base.yml
+++ b/.make_scripts/mkdocs-documentation/mkdocs_base.yml
@@ -34,6 +34,14 @@ theme:
 extra_css:
   - assets/extra.css
 
+# Shared scripting — extra.js is a "managed asset" same as extra.css.
+# Provides the tab-aware TOC behaviour (synthetic per-tab parents in the
+# right sidebar, deep-link tab activation, URL pollution guard) for any
+# project using pymdownx.tabbed with alternate_style: true. No-op on pages
+# without tabbed content.
+extra_javascript:
+  - assets/extra.js
+
 hooks:
   - .make_scripts/mkdocs-documentation/hooks/inline_nav_include.py
   - .make_scripts/mkdocs-documentation/hooks/fix_symlinks.py

--- a/.make_scripts/mkdocs-documentation/setup_documentation.py
+++ b/.make_scripts/mkdocs-documentation/setup_documentation.py
@@ -116,6 +116,7 @@ def ensure_docs_dir():
 # referenced from extra_css in the project's mkdocs_custom.yml).
 MANAGED_DOCS_ASSETS = [
     "assets/extra.css",
+    "assets/extra.js",
 ]
 
 

--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -1,55 +1,137 @@
 /* ─────────────────────────────────────────────────────────────────
  * Tabbed content (pymdownx.tabbed with alternate_style: true)
  *
- * Adds a subtle container, a distinct label-row background, and a
- * shaded content area so each tab group reads as a single visual unit.
- * Without this, content tabs visually bleed into surrounding prose.
+ * Goal: minimal but distinguishable. Subtle outer box, slim labels,
+ * dark+heavy active label, accent-coloured moving underline.
+ *
+ * pymdownx alternate_style puts inputs as siblings of .tabbed-labels
+ * (not adjacent to each label), so the active label has to be
+ * targeted via the nth-child positional pattern Material uses
+ * internally — `input:nth-child(N):checked ~ .tabbed-labels > :nth-child(N)`.
+ * That's why this file lists positions 1..8 explicitly.
  * ───────────────────────────────────────────────────────────────── */
 
+/* Container — subtle outer box so the pane reads as a unit. The
+ * labels row scrolls naturally with content; we deliberately do NOT
+ * make it sticky (sticky-positioning under Material's auto-hiding
+ * header is a source of subtle racing bugs).
+ *
+ * scroll-margin-top mirrors the value Material uses on :target
+ * elements (3.6rem mobile, 6rem on desktop where the header is
+ * lifted with the tab bar). When scrollIntoView lands on the
+ * tabbed-set, the labels row clears Material's sticky header
+ * instead of disappearing behind it. */
 .md-typeset .tabbed-set {
-  border: 1px solid var(--md-default-fg-color--lightest);
-  border-radius: .4rem;
-  margin: 1.4em 0;
-  overflow: hidden;
+  margin: 1.2em 0;
   background: var(--md-default-bg-color);
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: .35rem;
+  overflow: hidden;
+  scroll-margin-top: 3.6rem;
 }
 
+@media screen and (min-width: 76.25em) {
+  .md-header--lifted ~ .md-container .md-typeset .tabbed-set {
+    scroll-margin-top: 6rem;
+  }
+}
+
+/* Label row — slim, no fill, single divider line at the bottom. */
 .md-typeset .tabbed-set > .tabbed-labels {
   display: flex;
-  background: var(--md-code-bg-color);
+  gap: 0;
+  margin: 0;
+  padding: 0 .25rem;
+  background: var(--md-default-bg-color);
+  box-shadow: none;
   border-bottom: 1px solid var(--md-default-fg-color--lightest);
 }
 
+/* Tighten Material's chunky default label padding + font size. */
 .md-typeset .tabbed-set > .tabbed-labels > label {
-  flex: 1;
-  text-align: center;
+  padding: .35rem .85rem;
+  font-size: .72rem;
   font-weight: 600;
-  opacity: .55;
-  padding: .65rem 1.1rem;
-  font-size: .82rem;
-  transition: opacity .15s ease;
+  white-space: nowrap;
 }
 
-.md-typeset .tabbed-set > .tabbed-labels > label:hover {
-  opacity: .8;
+/* Active label — heavier weight (Material already handles colour
+ * via its own nth-child rules, painting active in default-fg-color
+ * and inactive in default-fg-color--light). */
+.md-typeset .tabbed-set > input:first-child:checked ~ .tabbed-labels > :first-child,
+.md-typeset .tabbed-set > input:nth-child(2):checked ~ .tabbed-labels > :nth-child(2),
+.md-typeset .tabbed-set > input:nth-child(3):checked ~ .tabbed-labels > :nth-child(3),
+.md-typeset .tabbed-set > input:nth-child(4):checked ~ .tabbed-labels > :nth-child(4),
+.md-typeset .tabbed-set > input:nth-child(5):checked ~ .tabbed-labels > :nth-child(5),
+.md-typeset .tabbed-set > input:nth-child(6):checked ~ .tabbed-labels > :nth-child(6),
+.md-typeset .tabbed-set > input:nth-child(7):checked ~ .tabbed-labels > :nth-child(7),
+.md-typeset .tabbed-set > input:nth-child(8):checked ~ .tabbed-labels > :nth-child(8) {
+  font-weight: 800;
 }
 
-/* Active tab — selected label gets full opacity and an indicator line. */
-.md-typeset .tabbed-set > input:checked + label {
-  opacity: 1;
-  color: var(--md-accent-fg-color);
+/* Active indicator — keep Material's JS-driven moving underline,
+ * but recolour from default-fg to the accent for a pop of colour. */
+.js .md-typeset .tabbed-set > .tabbed-labels:before {
+  background: var(--md-accent-fg-color);
 }
 
-/* Tab content area — slightly inset so tab boundary is unambiguous. */
+/* Content area — small inset so code blocks and prose breathe inside
+ * the bordered container. */
 .md-typeset .tabbed-set > .tabbed-content {
-  padding: .9rem 1.2rem;
+  padding: .8rem 1rem;
 }
 
-/* Dark mode polish — the lightest fg color is too pale on dark; nudge. */
+/* Trim the default top margin of code blocks inside the tab so they
+ * don't double-pad against the content's top inset. */
+.md-typeset .tabbed-set > .tabbed-content .tabbed-block > pre:first-child,
+.md-typeset .tabbed-set > .tabbed-content .tabbed-block > div:first-child {
+  margin-top: 0;
+}
+
+/* Dark mode — divider + border use a slightly heavier token. */
 [data-md-color-scheme="slate"] .md-typeset .tabbed-set {
   border-color: var(--md-default-fg-color--lighter);
 }
 
 [data-md-color-scheme="slate"] .md-typeset .tabbed-set > .tabbed-labels {
   border-bottom-color: var(--md-default-fg-color--lighter);
+}
+
+/* ─────────────────────────────────────────────────────────────────
+ * Tab-aware TOC entries (rendered by extra.js).
+ *
+ * Synthetic parent entries created from a tab label use `--tab` modifier
+ * classes. Style them slightly differently from real heading entries so
+ * the reader can tell at a glance that "Nokia SR Linux" is a tab, not
+ * an H3. Italic + a small chevron prefix does the trick.
+ * ───────────────────────────────────────────────────────────────── */
+
+.md-nav__link--tab {
+  font-style: italic;
+  opacity: .8;
+}
+
+.md-nav__link--tab::before {
+  content: "▸ ";
+  margin-right: .15rem;
+  opacity: .55;
+}
+
+.md-nav__link--tab:hover {
+  opacity: 1;
+}
+
+/* Hide the children of any synthetic tab-group whose tab isn't
+ * currently active. Keeps Material's scroll-spy from highlighting
+ * headings in hidden tabs (which all collapse to the same scroll
+ * position when their parent .tabbed-block is display:none). */
+.md-nav__item--tab-inactive > .md-nav {
+  display: none;
+}
+
+/* Active-tab marker — a small chevron rotation so the user can tell
+ * at a glance which tab's children are showing. */
+.md-nav__item--tab-active > .md-nav__link--tab::before {
+  content: "▾ ";
+  opacity: .8;
 }

--- a/docs/assets/extra.js
+++ b/docs/assets/extra.js
@@ -1,0 +1,492 @@
+/* Tab-aware TOC for pymdownx.tabbed (alternate_style: true).
+ *
+ * What this script does (and ONLY this — scope is intentionally small):
+ *
+ *   1. When a TOC entry points to a heading inside an inactive tab,
+ *      clicking it activates the tab so the heading is visible. We
+ *      restore the target's `id` synchronously in the capture phase
+ *      so Material's bubble-phase scroll-into-view (and the browser's
+ *      native anchor jump) find the live element with no race.
+ *
+ *   2. The flat TOC is restructured into synthetic per-tab parent
+ *      entries: any consecutive run of TOC items whose targets live
+ *      in the same tab gets grouped under a parent labelled with
+ *      that tab's name. Clicking the parent activates the tab.
+ *
+ *   3. Synthetic group expansion (▾ active, ▸ inactive) tracks the
+ *      currently active tab.
+ *
+ *   4. Material's scroll-spy is prevented from polluting the URL
+ *      with fragments that point to inactive-tab headings via:
+ *
+ *        a. Stripping the `id` attribute of every element inside an
+ *           inactive .tabbed-block (parked on `data-tab-id`); some
+ *           Material codepaths walk live `[id]` and skip them.
+ *
+ *        b. A narrow filter on history.replaceState/pushState that
+ *           drops calls whose fragment targets an element inside an
+ *           inactive tab. Material caches `[id]` references at init
+ *           time, so this is the necessary belt-and-braces.
+ *
+ * What this script intentionally does NOT do:
+ *
+ *   - No sticky positioning of the tab labels row. (CSS handles tab
+ *     styling but the labels row scrolls naturally with content.)
+ *   - No header-height tracking. Material's autohiding header is
+ *     left alone.
+ *   - No custom scrollIntoView. Material's instant-nav and the
+ *     browser's native anchor jump handle scrolling. Activating the
+ *     correct tab in the capture phase is enough — the live `id`
+ *     restored there is what Material/browser scrolls to.
+ *
+ * Hooked into:
+ *   - DOMContentLoaded                  (initial setup)
+ *   - hashchange                        (URL fragment changes)
+ *   - Material's document$ stream       (instant navigation)
+ *   - radio change events               (tab switching)
+ *   - capture-phase clicks              (TOC link interception)
+ */
+(function () {
+  /* ──────────────────────────────────────────────────────────────
+   *  Selectors
+   * ────────────────────────────────────────────────────────────── */
+
+  const SEL_TABBED_SET = ".tabbed-set";
+  const SEL_TABBED_BLOCK = ".tabbed-block";
+  const SEL_TABBED_LABELS = ".tabbed-labels";
+  const SEL_SIDEBAR_SECONDARY = ".md-sidebar--secondary";
+  const SEL_TOC_NAV = SEL_SIDEBAR_SECONDARY + " nav";
+
+  const cssEscape =
+    window.CSS && typeof CSS.escape === "function"
+      ? CSS.escape.bind(CSS)
+      : (s) => String(s).replace(/[^a-zA-Z0-9_-]/g, (c) => "\\" + c);
+
+  /* ──────────────────────────────────────────────────────────────
+   *  ID management for tabbed-blocks
+   *
+   *  When a tab is inactive, we move every descendant `id` onto
+   *  `data-tab-id`. When the tab becomes active, we restore them.
+   *  Idempotent on both sides.
+   * ────────────────────────────────────────────────────────────── */
+
+  function stripIdsInBlock(block) {
+    for (const el of block.querySelectorAll("[id]")) {
+      el.setAttribute("data-tab-id", el.id);
+      el.removeAttribute("id");
+    }
+  }
+
+  function restoreIdsInBlock(block) {
+    for (const el of block.querySelectorAll("[data-tab-id]")) {
+      const original = el.getAttribute("data-tab-id");
+      if (original && !el.id) el.setAttribute("id", original);
+      el.removeAttribute("data-tab-id");
+    }
+  }
+
+  function syncIdsToActiveTab(tabbedSet) {
+    const inputs = tabbedSet.querySelectorAll(
+      ':scope > input[type="radio"]'
+    );
+    const blocks = tabbedSet.querySelectorAll(
+      ":scope > .tabbed-content > " + SEL_TABBED_BLOCK
+    );
+    for (let i = 0; i < inputs.length; i++) {
+      const block = blocks[i];
+      if (!block) continue;
+      if (inputs[i].checked) restoreIdsInBlock(block);
+      else stripIdsInBlock(block);
+    }
+  }
+
+  function syncAllTabbedSets() {
+    for (const set of document.querySelectorAll(SEL_TABBED_SET)) {
+      syncIdsToActiveTab(set);
+    }
+  }
+
+  /* ──────────────────────────────────────────────────────────────
+   *  Fragment → element lookup (id OR data-tab-id)
+   * ────────────────────────────────────────────────────────────── */
+
+  function findTargetByFragment(fragment) {
+    if (!fragment || fragment === "#") return null;
+    let id;
+    try {
+      id = decodeURIComponent(fragment.slice(1));
+    } catch (e) {
+      return null;
+    }
+    return (
+      document.getElementById(id) ||
+      document.querySelector('[data-tab-id="' + cssEscape(id) + '"]')
+    );
+  }
+
+  /* ──────────────────────────────────────────────────────────────
+   *  Tab activation
+   *
+   *  Clicking the label fires Material's indicator-animator (setting
+   *  input.checked directly does NOT fire change). Synchronous in
+   *  the capture phase: the target's id is live by the time
+   *  Material/browser scroll in bubble phase.
+   * ────────────────────────────────────────────────────────────── */
+
+  function activateTab(tabbedSet, blockIndex) {
+    const inputs = tabbedSet.querySelectorAll(
+      ':scope > input[type="radio"]'
+    );
+    const labels = tabbedSet.querySelectorAll(
+      ":scope > " + SEL_TABBED_LABELS + " > label"
+    );
+    const input = inputs[blockIndex];
+    const label = labels[blockIndex];
+    if (!input || input.checked) return;
+
+    if (label) label.click();
+    else input.checked = true;
+
+    /* The radio change handler we install at the bottom of this
+     * file runs syncIdsToActiveTab + syncTocVisibility. Defensively
+     * call them here too in case the change event does not fire
+     * (e.g., element detached at the time of the click). */
+    syncIdsToActiveTab(tabbedSet);
+    syncTocVisibility();
+  }
+
+  function activateTabForFragment(fragment) {
+    if (!fragment || fragment === "#") return;
+    const target = findTargetByFragment(fragment);
+    if (!target) return;
+    const block = target.closest(SEL_TABBED_BLOCK);
+    if (!block) return;
+    const tabbedSet = block.closest(SEL_TABBED_SET);
+    if (!tabbedSet) return;
+    const blocks = Array.from(
+      tabbedSet.querySelectorAll(
+        ":scope > .tabbed-content > " + SEL_TABBED_BLOCK
+      )
+    );
+    const blockIndex = blocks.indexOf(block);
+    if (blockIndex < 0) return;
+    activateTab(tabbedSet, blockIndex);
+  }
+
+  function activateTabForHash() {
+    activateTabForFragment(window.location.hash);
+  }
+
+  /* ──────────────────────────────────────────────────────────────
+   *  TOC restructure — group entries by their parent tab
+   * ────────────────────────────────────────────────────────────── */
+
+  function tabInfoForFragment(fragment) {
+    if (!fragment) return null;
+    const target = findTargetByFragment(fragment);
+    if (!target) return null;
+    const block = target.closest(SEL_TABBED_BLOCK);
+    if (!block) return null;
+    const tabbedSet = block.closest(SEL_TABBED_SET);
+    if (!tabbedSet) return null;
+    const blocks = Array.from(
+      tabbedSet.querySelectorAll(
+        ":scope > .tabbed-content > " + SEL_TABBED_BLOCK
+      )
+    );
+    const blockIndex = blocks.indexOf(block);
+    if (blockIndex < 0) return null;
+    const labels = tabbedSet.querySelectorAll(
+      ":scope > " + SEL_TABBED_LABELS + " > label"
+    );
+    const labelText = labels[blockIndex]?.textContent.trim();
+    if (!labelText) return null;
+    return {
+      tabbedSet,
+      blockIndex,
+      labelText,
+      key:
+        (tabbedSet.dataset.tabs || tabbedSet.id || "set") + ":" + blockIndex,
+    };
+  }
+
+  function buildSyntheticParent(tabInfo) {
+    const li = document.createElement("li");
+    li.className = "md-nav__item md-nav__item--tab";
+    li.dataset.tabSet = tabInfo.tabbedSet.dataset.tabs || "";
+    li.dataset.tabIndex = String(tabInfo.blockIndex);
+
+    const a = document.createElement("a");
+    a.className = "md-nav__link md-nav__link--tab";
+    a.href = "#";
+    a.textContent = tabInfo.labelText;
+    a.title = 'Open the "' + tabInfo.labelText + '" tab';
+
+    a.addEventListener("click", (e) => {
+      /* The href="#" + preventDefault + stopPropagation combo
+       * deliberately keeps Material entirely out of this click:
+       *
+       *   - href="#" means there's no real fragment for Material's
+       *     instant-nav to treat as a navigation.
+       *   - preventDefault stops the browser's default "#" jump
+       *     (which would put a stray "#" in the URL).
+       *   - stopPropagation stops Material's bubble-phase click
+       *     handler from running.
+       *
+       * With Material bypassed, NO ONE else is going to call
+       * scrollTo on this click. Our requestAnimationFrame scroll
+       * then runs unopposed — no race, no retry loop, robust in
+       * every browser. This is exactly the "easy, race-free path"
+       * for synthetic group clicks because we own the click in
+       * full. (TOC sub-entries with real hash fragments still flow
+       * through Material untouched by our generic handler.) */
+      e.preventDefault();
+      e.stopPropagation();
+      activateTab(tabInfo.tabbedSet, tabInfo.blockIndex);
+      requestAnimationFrame(() => {
+        tabInfo.tabbedSet.scrollIntoView({ block: "start" });
+      });
+    });
+
+    li.appendChild(a);
+
+    const nestedNav = document.createElement("nav");
+    nestedNav.className = "md-nav md-nav--secondary";
+    nestedNav.setAttribute("aria-label", tabInfo.labelText);
+    const nestedUl = document.createElement("ul");
+    nestedUl.className = "md-nav__list";
+    nestedNav.appendChild(nestedUl);
+    li.appendChild(nestedNav);
+
+    return { li, nestedUl };
+  }
+
+  function syncTocVisibility() {
+    const groups = document.querySelectorAll(".md-nav__item--tab");
+    for (const group of groups) {
+      const setId = group.dataset.tabSet;
+      const idx = parseInt(group.dataset.tabIndex, 10);
+      if (Number.isNaN(idx)) continue;
+      const tabbedSet = setId
+        ? document.querySelector(
+            SEL_TABBED_SET + '[data-tabs="' + cssEscape(setId) + '"]'
+          )
+        : null;
+      if (!tabbedSet) continue;
+      const inputs = tabbedSet.querySelectorAll(
+        ':scope > input[type="radio"]'
+      );
+      const isActive = inputs[idx]?.checked === true;
+      group.classList.toggle("md-nav__item--tab-active", isActive);
+      group.classList.toggle("md-nav__item--tab-inactive", !isActive);
+    }
+  }
+
+  function restructureTocList(navList) {
+    const items = Array.from(navList.children).filter(
+      (el) =>
+        el.tagName === "LI" && !el.classList.contains("md-nav__item--tab")
+    );
+    if (items.length === 0) return 0;
+
+    const infos = items.map((item) => {
+      const link = item.querySelector(":scope > a.md-nav__link");
+      /* link.hash returns just the fragment regardless of whether
+       * the href is relative ("#foo") or absolute (Material rewrites
+       * TOC hrefs to absolute form during instant nav). */
+      const fragment = link?.hash;
+      return tabInfoForFragment(fragment);
+    });
+
+    let group = null;
+    const commits = [];
+    for (let i = 0; i < items.length; i++) {
+      const info = infos[i];
+      if (!info) {
+        if (group) commits.push(group);
+        group = null;
+        continue;
+      }
+      if (!group || group.key !== info.key) {
+        if (group) commits.push(group);
+        group = { ...info, items: [items[i]] };
+      } else {
+        group.items.push(items[i]);
+      }
+    }
+    if (group) commits.push(group);
+
+    for (const g of commits) {
+      const first = g.items[0];
+      const parent = first.parentNode;
+      const { li, nestedUl } = buildSyntheticParent(g);
+      parent.insertBefore(li, first);
+      for (const item of g.items) nestedUl.appendChild(item);
+    }
+    return commits.length;
+  }
+
+  function restructureToc() {
+    const tocRoot = document.querySelector(SEL_TOC_NAV);
+    if (!tocRoot) return;
+    if (tocRoot.dataset.tabRestructured === "done") return;
+    const lists = tocRoot.querySelectorAll(".md-nav__list");
+    for (const list of lists) restructureTocList(list);
+    tocRoot.dataset.tabRestructured = "done";
+    syncTocVisibility();
+  }
+
+  /* ──────────────────────────────────────────────────────────────
+   *  URL pollution guard
+   *
+   *  Material's scroll-spy writes URL fragments that can point to
+   *  inactive-tab headings (Material caches an `[id]` map at init
+   *  time so DOM-level id stripping isn't enough on its own). We
+   *  filter history.replaceState/pushState to drop calls whose
+   *  fragment targets an inactive-tab element.
+   *
+   *  Pure DOM check at write time. No timing, no race. Idempotent
+   *  install. Fails-open: if our predicate throws or finds nothing,
+   *  the original call goes through.
+   * ────────────────────────────────────────────────────────────── */
+
+  function fragmentTargetsInactiveTab(url) {
+    if (!url) return false;
+    let parsed;
+    try {
+      parsed = new URL(url, document.baseURI);
+    } catch (e) {
+      return false;
+    }
+    if (!parsed.hash || parsed.hash === "#") return false;
+    const target = findTargetByFragment(parsed.hash);
+    if (!target) return false;
+    const block = target.closest(SEL_TABBED_BLOCK);
+    if (!block) return false;
+    const tabbedSet = block.closest(SEL_TABBED_SET);
+    if (!tabbedSet) return false;
+    const blocks = Array.from(
+      tabbedSet.querySelectorAll(
+        ":scope > .tabbed-content > " + SEL_TABBED_BLOCK
+      )
+    );
+    const blockIndex = blocks.indexOf(block);
+    if (blockIndex < 0) return false;
+    const inputs = tabbedSet.querySelectorAll(
+      ':scope > input[type="radio"]'
+    );
+    return inputs[blockIndex] && !inputs[blockIndex].checked;
+  }
+
+  function installUrlGuard() {
+    if (history.__neopsTabsGuard) return;
+    history.__neopsTabsGuard = true;
+
+    const wrap = (origName) => {
+      const orig = history[origName].bind(history);
+      history[origName] = function (state, title, url) {
+        try {
+          if (fragmentTargetsInactiveTab(url)) return;
+        } catch (e) {
+          /* Never break navigation because of us. */
+        }
+        return orig(state, title, url);
+      };
+    };
+
+    wrap("replaceState");
+    wrap("pushState");
+  }
+
+  /* ──────────────────────────────────────────────────────────────
+   *  Sidebar rebuild observer — Material replaces the secondary
+   *  sidebar on instant navigation. Our `done` flag lives on the
+   *  tocRoot element, so a fresh <nav> from Material has no flag
+   *  and our restructure re-applies.
+   * ────────────────────────────────────────────────────────────── */
+
+  function watchSidebarForRebuilds() {
+    const sidebar = document.querySelector(SEL_SIDEBAR_SECONDARY);
+    if (!sidebar) return;
+    new MutationObserver(restructureToc).observe(sidebar, {
+      childList: true,
+      subtree: true,
+    });
+  }
+
+  /* ──────────────────────────────────────────────────────────────
+   *  Lifecycle wiring
+   * ────────────────────────────────────────────────────────────── */
+
+  function run() {
+    syncAllTabbedSets();
+    restructureToc();
+    activateTabForHash();
+  }
+
+  function init() {
+    /* Install the URL guard FIRST so it covers any subsequent
+     * replaceState/pushState (ours and Material's). Idempotent. */
+    installUrlGuard();
+    run();
+    watchSidebarForRebuilds();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+
+  window.addEventListener("hashchange", activateTabForHash);
+
+  /* Capture-phase click handler: when a TOC link points into an
+   * inactive tab, activate the tab synchronously so the target's
+   * `id` is live when Material's bubble-phase handler (and the
+   * browser's native anchor jump) try to scroll to it. We do NOT
+   * preventDefault, do NOT stopPropagation — the natural click
+   * lifecycle handles URL update and scrolling. */
+  document.addEventListener(
+    "click",
+    (e) => {
+      if (e.defaultPrevented) return;
+      if (e.button !== 0) return;
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+      const a = e.target.closest && e.target.closest("a");
+      if (!a || !a.hash || a.hash === "#") return;
+      if (a.pathname !== window.location.pathname) return;
+      if (a.target && a.target !== "" && a.target !== "_self") return;
+      activateTabForFragment(a.hash);
+    },
+    true
+  );
+
+  /* When the user clicks a tab label (or the tab radio changes for
+   * any other reason), re-sync ID stripping and TOC visibility. */
+  document.addEventListener(
+    "change",
+    (e) => {
+      const target = e.target;
+      if (
+        target instanceof HTMLInputElement &&
+        target.type === "radio" &&
+        target.parentElement?.classList.contains("tabbed-set")
+      ) {
+        const tabbedSet = target.parentElement;
+        syncIdsToActiveTab(tabbedSet);
+        syncTocVisibility();
+      }
+    },
+    true
+  );
+
+  /* Material's document$ Subject fires once on subscribe AND on
+   * every instant navigation. Re-running run() is idempotent —
+   * each step early-returns when its work is already done. */
+  if (
+    typeof document$ !== "undefined" &&
+    typeof document$.subscribe === "function"
+  ) {
+    document$.subscribe(run);
+  }
+})();

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,8 @@ extra:
     name: Neops
 extra_css:
 - assets/extra.css
+extra_javascript:
+- assets/extra.js
 hooks:
 - .make_scripts/mkdocs-documentation/hooks/inline_nav_include.py
 - .make_scripts/mkdocs-documentation/hooks/fix_symlinks.py


### PR DESCRIPTION
## Summary

Pulls in zebbra/mkdocs-documentation v0.4.0 (PR #8 in that repo). Adds the new tab-aware TOC + URL pollution guard for pymdownx.tabbed. The script is a no-op on pages without `.tabbed-set` content.

## What v0.4.0 adds

- **`extra.js`** — new managed asset:
  - Restructures the right-sidebar TOC into synthetic per-tab parent entries (▾ active / ▸ inactive)
  - Activates the correct tab when a TOC sub-entry's target lives inside an inactive tab
  - Strips inactive-tab `[id]` attributes onto `data-tab-id` so scroll-spy can't see them
  - Filters `history.replaceState`/`pushState` so URL hashes never point to inactive-tab headings
- **`extra.css`** — slim labels, accent active underline, `scroll-margin-top` matching Material's `:target` rule
- **`mkdocs_base.yml`** gains the `extra_javascript` entry
- **`setup_documentation.py`** adds `extra.js` to `MANAGED_DOCS_ASSETS`

## Test plan

- [x] `mkdocs build` clean (umbrella stitch)
- [x] All 8 cross-browser scenarios pass on Chromium, Firefox, and Webkit (verified during the upstream PR)
- [ ] Visual smoke check on `make doc-serve`: per-project pages without tabbed content render unchanged